### PR TITLE
feat(site): theme toggle + CSS extraction (phase 1)

### DIFF
--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -21,4 +21,14 @@ ul{margin:0 0 0 18px}
 .skip-link:focus{position:static;width:auto;height:auto;padding:8px 12px;background:var(--accent);color:#000;border-radius:8px}
 /* Footer */
 footer{margin-top:20px}
+/* Header title spacing (moved from inline style) */
+header h1{margin:8px 0}
+
+/* Explicit theme toggles override system preference */
+html[data-theme="dark"]{
+  --bg:#0b1020;--card:#151b34;--text:#eef2ff;--muted:#a2b0d6;--link:#7dd3fc;--border:#28314f;--accent:#22d3ee;
+}
+html[data-theme="light"]{
+  --bg:#f6f7fb;--card:#fff;--text:#0f172a;--muted:#4b5563;--link:#0ea5e9;--border:#e5e7eb;--accent:#06b6d4;
+}
 

--- a/site/assets/js/theme-toggle.js
+++ b/site/assets/js/theme-toggle.js
@@ -1,0 +1,37 @@
+(function(){
+  const KEY = 'theme';
+  const root = document.documentElement;
+  const btn = document.getElementById('theme-toggle');
+
+  function apply(theme){
+    if (theme === 'dark' || theme === 'light'){
+      root.setAttribute('data-theme', theme);
+      try { localStorage.setItem(KEY, theme); } catch(_) {}
+      if (btn){
+        btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+        btn.textContent = theme === 'dark' ? 'Thème: sombre' : 'Thème: clair';
+      }
+    } else {
+      root.removeAttribute('data-theme');
+      try { localStorage.removeItem(KEY); } catch(_) {}
+    }
+  }
+
+  const saved = (()=>{ try { return localStorage.getItem(KEY); } catch(_) { return null; } })();
+  if (saved){
+    apply(saved);
+  } else if (btn){
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    btn.setAttribute('aria-pressed', prefersDark ? 'true' : 'false');
+    btn.textContent = prefersDark ? 'Thème: sombre' : 'Thème: clair';
+  }
+
+  if (btn){
+    btn.addEventListener('click', function(){
+      const current = root.getAttribute('data-theme') || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      const next = current === 'dark' ? 'light' : 'dark';
+      apply(next);
+    });
+  }
+})();
+

--- a/site/index.html
+++ b/site/index.html
@@ -15,6 +15,7 @@
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
   <link rel="stylesheet" href="/assets/css/site.css" />
   <script src="/assets/js/contents.js" defer></script>
+  <script src="/assets/js/theme-toggle.js" defer></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => navigator.serviceWorker.register('/sw.js').catch(()=>{}))
@@ -25,10 +26,11 @@
   <a class="skip-link" href="#main">Aller au contenu</a>
   <div class="wrap">
     <header>
-      <h1 style="margin:8px 0">Interface Maths 2025–2026 — Aperçu</h1>
+      <h1>Interface Maths 2025–2026 — Aperçu</h1>
       <nav aria-label="Navigation principale">
         <a class="btn" href="/">Accueil</a>
         <a class="btn" href="/content/">/content (alias)</a>
+        <button id="theme-toggle" class="btn" type="button" aria-pressed="false" aria-label="Basculer le thème">Thème</button>
       </nav>
     </header>
 


### PR DESCRIPTION
- Remove inline h1 margin from index.html (moved to CSS)\n- Add theme toggle (button + JS, persisted in localStorage)\n- Add explicit html[data-theme] overrides for dark/light to complement prefers-color-scheme\n\nNext phases: extract inline styles from other pages and unify shared components.