### PR TITLE
feat(css): extract inline styles (phase 4 – Maths expertes chap1)

### DIFF
--- a/site/Maths_expertes/Arithmetique/Chap1_divisibilite_congruence/chap1_divisibilite_congruence.html
+++ b/site/Maths_expertes/Arithmetique/Chap1_divisibilite_congruence/chap1_divisibilite_congruence.html
@@ -58,7 +58,7 @@
     <div class="toolbar">
       <div>
 <h1>Arithmétique - Partie 1 : Divisibilité et congruences <span class="badge">Arithmétique : cours intégral + outils</span></h1>
-        <p class="muted" style="margin:4px 0 0">Terminale — Maths expertes</p>
+        <p class="muted mt-4 mb-0">Terminale — Maths expertes</p>
         <small class="muted">Auteur : <strong>Alaeddine Ben Rhouma</strong> — Lycée Pierre Mendès France, Tunis • © Propriété intellectuelle • Raccourcis : <kbd>Ctrl</kbd>+<kbd>B</kbd> (Tableau), <kbd>?</kbd> (Aide)</small>
       </div>
       <div class="buttons">
@@ -326,8 +326,8 @@
     <h2>Encart Python — Algorithme d’Euclide (Pyodide)</h2>
     <p class="muted">Les sorties <code>print</code> apparaissent ci‑dessous (stdout/stderr capturés). Saisir a et b, puis exécuter.</p>
       <div class="control-row"><label class="muted" for="pyA">a</label><input id="pyA" class="input" type="number" value="114"><label class="muted" for="pyB">b</label><input id="pyB" class="input" type="number" value="8"><label class="muted" for="autoCode"><input type="checkbox" id="autoCode" checked> Remplir le code automatiquement</label></div>
-    <div class="control-row" style="margin-top:6px"><button class="btn" id="loadPy">⚙️ Charger Pyodide</button><span id="pyStatus" class="muted" aria-live="polite">non chargé</span></div>
-    <textarea id="pyCode" class="input mono" rows="10" style="width:100%;margin-top:10px" aria-label="Zone de code Python"># Saisissez a et b ci-dessus ou éditez ce code puis Exécuter
+    <div class="control-row mt-6"><button class="btn" id="loadPy">⚙️ Charger Pyodide</button><span id="pyStatus" class="muted" aria-live="polite">non chargé</span></div>
+<textarea id="pyCode" class="input mono w-100 mt-10" rows="10" aria-label="Zone de code Python">
 # Exemple : a=114, b=8
 
 def egcd(a,b):
@@ -346,8 +346,8 @@ for s in steps:
     print(s)
 print("PGCD:", g)
 </textarea>
-    <div class="control-row" style="margin-top:8px"><button class="btn" id="runPy" disabled>▶️ Exécuter</button><button class="btn" id="clearPy" disabled>🧹 Effacer</button></div>
-    <pre id="pyOut" class="result" style="white-space:pre-wrap" aria-live="polite"></pre>
+    <div class="control-row mt-8"><button class="btn" id="runPy" disabled>▶️ Exécuter</button><button class="btn" id="clearPy" disabled>🧹 Effacer</button></div>
+<pre id="pyOut" class="result pre-wrap" aria-live="polite"></pre>
   </section>
 
   <!-- Auto-tests (développeur) -->
@@ -362,7 +362,7 @@ print("PGCD:", g)
     </details>
   </section>
 
-  <footer class="muted" style="margin-top:22px">© 2025 — Support interactif conçu et rédigé par <strong>Alaeddine Ben Rhouma</strong>. Tous droits réservés.</footer>
+  <footer class="muted mt-22">© 2025 — Support interactif conçu et rédigé par <strong>Alaeddine Ben Rhouma</strong>. Tous droits réservés.</footer>
   <div class="sticky-footer"><button class="btn" onclick="scrollTo(0,0)">⬆️ Haut</button></div>
 </div>
 

--- a/site/Maths_expertes/Arithmetique/Chap1_divisibilite_congruence/fiche_eleve_arith_chap1.html
+++ b/site/Maths_expertes/Arithmetique/Chap1_divisibilite_congruence/fiche_eleve_arith_chap1.html
@@ -113,7 +113,7 @@
 
         <section class="card" id="props">
           <h2>Propriétés P1→P7 — utilité & pièges</h2>
-          <div class="control-row" style="margin-bottom:8px"><button class="btn" id="btnOpenProps" aria-pressed="false" type="button">Tout ouvrir</button></div>
+          <div class="control-row mb-8"><button class="btn" id="btnOpenProps" aria-pressed="false" type="button">Tout ouvrir</button></div>
 
           <details><summary><strong>P1</strong> — Si $b\mid a$ alors $a\Z\subset b\Z$ et $D(b)\subset D(a)$</summary>
             <div class="step"><div class="n">Utilité</div><div>Comparer des <b>ensembles de multiples/diviseurs</b> et prouver des inclusions rapidement.</div></div>
@@ -162,7 +162,7 @@
 
         <section class="card" id="methodo">
           <h2>Méthodologie par type d’exercice</h2>
-          <div class="control-row" style="margin-bottom:8px"><button class="btn" id="btnOpenMethodo" aria-pressed="false" type="button">Tout ouvrir</button></div>
+          <div class="control-row mb-8"><button class="btn" id="btnOpenMethodo" aria-pressed="false" type="button">Tout ouvrir</button></div>
           <details open><summary><strong>A. Tester une divisibilité</strong> ($b\mid a$ ?)</summary>
             <div class="step"><div class="n">1</div><div>Essayer d’écrire $a=bk$ (calculer $k=a/b$ ; vérifier qu’il est entier).</div></div>
             <div class="step"><div class="n">2</div><div>Sinon, faire la <b>division euclidienne</b> : $a=bq+r$ ; si $r=0$ ⇒ $b\mid a$.</div></div>
@@ -214,7 +214,7 @@
 
         <section class="card" id="entrainement">
           <h2>Mini‑entraînements éclair</h2>
-          <div class="control-row" style="margin-bottom:8px"><button class="btn" id="btnOpenEntrain" aria-pressed="false" type="button">Tout ouvrir</button></div>
+          <div class="control-row mb-8"><button class="btn" id="btnOpenEntrain" aria-pressed="false" type="button">Tout ouvrir</button></div>
           <div class="step"><div class="n">1</div><div>Compléter : « $56=17\times3+5=17\times2+22$ mais la seconde n’est pas euclidienne car <input class="input mono" id="qA" size="10" placeholder=">" aria-label="Justification (ex. 22 > 17)">. » <button class="btn" onclick="checkText('qA','22 > 17')">Vérifier</button> <span id="qAr" aria-live="polite"></span></div></div>
           <div class="step"><div class="n">2</div><div>Résoudre $5x\equiv 1\pmod{12}$. <details><summary>Correction</summary>$\operatorname{pgcd}(5,12)=1$, $5^{-1}\equiv 5\pmod{12}$ ⇒ $x\equiv 5\pmod{12}$.</details></div></div>
           <div class="step"><div class="n">3</div><div>Déterminer $D(18)$ puis vérifier $D(9)\subset D(18)$. <details><summary>Correction</summary>$D(18)=\{-18, -9, -6, -3, -2, -1, 1, 2, 3, 6, 9, 18\}$, $D(9)=\{-9, -3, -1, 1, 3, 9\}$.</details></div></div>
@@ -230,7 +230,7 @@
           </ul>
         </section>
 
-        <footer class="muted" style="margin-top:22px">© 2025 — Fiche mémo & méthodologie conçue par <strong>Alaeddine Ben Rhouma</strong> (Maths expertes). Tous droits réservés.</footer>
+        <footer class="muted mt-22">© 2025 — Fiche mémo & méthodologie conçue par <strong>Alaeddine Ben Rhouma</strong> (Maths expertes). Tous droits réservés.</footer>
         <div class="sticky-footer"><button class="btn" onclick="scrollTo(0,0)">⬆️ Haut</button> <button class="btn" id="toggleAll" aria-pressed="false">🧩 Tout déplier/replier</button></div>
       </div>
 

--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -37,4 +37,11 @@ html[data-theme="light"]{
 .table-simple th,.table-simple td{border:1px solid var(--border);padding:4px}
 .mt-22{margin-top:22px}
 .mb-8{margin-bottom:8px}
+.mt-4{margin-top:4px}
+.mt-6{margin-top:6px}
+.mt-8{margin-top:8px}
+.mt-10{margin-top:10px}
+.mb-0{margin-bottom:0}
+.w-100{width:100%}
+.pre-wrap{white-space:pre-wrap}
 


### PR DESCRIPTION
- Add utilities: .mt-4,.mt-6,.mt-8,.mt-10,.mb-0,.w-100,.pre-wrap\n- Replace inline styles in Maths expertes Chap1 (cours + fiche)\n\nNext: sweep remaining pages for any stray inline styles and add print refinements.