### PR TITLE
feat(print): global print styles (site-wide)

### DIFF
--- a/site/assets/css/site.css
+++ b/site/assets/css/site.css
@@ -43,5 +43,14 @@ html[data-theme="light"]{
 .mt-10{margin-top:10px}
 .mb-0{margin-bottom:0}
 .w-100{width:100%}
-.pre-wrap{white-space:pre-wrap}
+pre-wrap{white-space:pre-wrap}
+
+/* Global print styles: hide interactive UI and flatten layout for printing */
+@media print{
+  .buttons, .sticky-footer, nav.card{display:none !important}
+  .grid.cols-2{grid-template-columns:1fr !important}
+  details{display:block}
+  details>summary{display:none}
+  details>*{display:block}
+}
 


### PR DESCRIPTION
- Hide interactive UI (buttons, sticky-footer, nav.card) when printing\n- Flatten 2-column grid to single column\n- Expand details sections for print\n\nThis centralizes print behavior for all pages and reduces per-page inline CSS.